### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The demo described above is difficult and brittle to put together with regular `
 
 ### Behind the scences 
 
-The demo was accomplished with [Jinja](http://jinja.pocoo.org/) templating, several [advanced kubernetes primitives & patterns](Advanced.md) that are currently in Alpha, and extending and adding some functionality to the `cncfdemo` wrapper - all in order to greatly simplify and reduce the number of commands required to accomplish a complex deployment.
+The demo was accomplished with [Jinja](http://jinja.pocoo.org/) templating, several [advanced kubernetes primitives & patterns](Kubernetes/Docs/Advanced.md) that are currently in Alpha, and extending and adding some functionality to the `cncfdemo` wrapper - all in order to greatly simplify and reduce the number of commands required to accomplish a complex deployment.
 
 ### Future Plans
 


### PR DESCRIPTION
For "[advanced kubernetes primitives & patterns]" added this "Kubernetes/Docs/Advanced.md" for correct link. Now the link is not broken.